### PR TITLE
chore: Add initial folder structure for hexagonal architecture

### DIFF
--- a/src/main/java/com/uguimar/notificationsms/application/port/input/HOLA.java
+++ b/src/main/java/com/uguimar/notificationsms/application/port/input/HOLA.java
@@ -1,0 +1,4 @@
+package com.uguimar.notificationsms.application.port.input;
+
+public class HOLA {
+}

--- a/src/main/java/com/uguimar/notificationsms/application/port/output/Hola1.java
+++ b/src/main/java/com/uguimar/notificationsms/application/port/output/Hola1.java
@@ -1,0 +1,4 @@
+package com.uguimar.notificationsms.application.port.output;
+
+public class Hola1 {
+}

--- a/src/main/java/com/uguimar/notificationsms/application/service/hola2.java
+++ b/src/main/java/com/uguimar/notificationsms/application/service/hola2.java
@@ -1,0 +1,4 @@
+package com.uguimar.notificationsms.application.service;
+
+public class hola2 {
+}

--- a/src/main/java/com/uguimar/notificationsms/domain/exception/hola3.java
+++ b/src/main/java/com/uguimar/notificationsms/domain/exception/hola3.java
@@ -1,0 +1,4 @@
+package com.uguimar.notificationsms.domain.exception;
+
+public class hola3 {
+}

--- a/src/main/java/com/uguimar/notificationsms/domain/model/hola4.java
+++ b/src/main/java/com/uguimar/notificationsms/domain/model/hola4.java
@@ -1,0 +1,4 @@
+package com.uguimar.notificationsms.domain.model;
+
+public class hola4 {
+}

--- a/src/main/java/com/uguimar/notificationsms/infrastructure/hola5.java
+++ b/src/main/java/com/uguimar/notificationsms/infrastructure/hola5.java
@@ -1,0 +1,4 @@
+package com.uguimar.notificationsms.infrastructure;
+
+public class hola5 {
+}


### PR DESCRIPTION
¿Qué se hizo?
Se agregó la estructura base de carpetas necesarias para implementar la arquitectura hexagonal (application, domain, infrastructure) dentro del proyecto.

¿Por qué se hizo?
Esta organización facilitará la implementación modular, el desacoplamiento de responsabilidades y una mejor mantenibilidad del código conforme avance el desarrollo.

Notas adicionales
Dentro de algunas carpetas se agregaron archivos temporales ( clases ) para el registro de Git.
Estos archivos serán eliminados a medida que se incorporen clases o módulos funcionales en cada capa.